### PR TITLE
run production from public_production folder to avoid downtime while building to public

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@
 package-lock.json
 yarn.lock
 
+# build step builds to public but during the building site is down
+# so to avoid downtime, it will build to public and then overwrite public_production
+public_production
+
 # Logs
 logs
 *.log

--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
     "url": "git+https://github.com/gatsbyjs/gatsby-starter-blog.git"
   },
   "scripts": {
-    "build": "gatsby build",
-    "postbuild_surge": "cd public && echo 'trafikito.surge.sh' > CNAME && surge && cd ..",
+    "build": "gatsby build --prefix-paths",
+    "postbuild": "rm -rf ./public_production && mv public public_production",
     "develop": "gatsby develop",
     "start": "npm run develop",
     "serve": "gatsby serve",


### PR DESCRIPTION
run production from public_production folder to avoid downtime while building to public
